### PR TITLE
customer-metrics-by-days-since-acquisition

### DIFF
--- a/models/marts/calendar_days.sql
+++ b/models/marts/calendar_days.sql
@@ -1,0 +1,12 @@
+with calendar as (
+    {{ dbt_utils.date_spine(
+        datepart="day",
+        start_date="cast('2021-01-01' as date)",
+        end_date="cast(current_date() as date)"
+        )
+    }}
+)
+
+select *
+from calendar
+order by date_day

--- a/models/marts/calendar_weeks.sql
+++ b/models/marts/calendar_weeks.sql
@@ -1,0 +1,12 @@
+with calendar as (
+    {{ dbt_utils.date_spine(
+        datepart="week",
+        start_date="cast(date_trunc('2021-01-01', week) as date)",
+        end_date="cast(current_date() as date)"
+        )
+    }}
+)
+
+select *
+from calendar
+order by date_week

--- a/models/marts/customers_weekly_metrics.sql
+++ b/models/marts/customers_weekly_metrics.sql
@@ -1,20 +1,31 @@
-with weeks_as_customer as (
+with days_as_customer as (
     select
         customer_id,
-        row_number() over (partition by customer_id order by calendar.date_week) as week,
-        calendar.date_week
+        row_number() over (partition by customer_id order by calendar.date_day) as total_days
     
     from {{ ref('dim_customers') }} customers
-        cross join {{ ref('calendar_weeks') }} calendar
-    where calendar.date_week >= cast(date_trunc(customers.first_order_at, week) as date)
+        cross join {{ ref('calendar_days') }} calendar
+    where calendar.date_day >= cast(customers.first_order_at as date)
+),
+
+weeks_as_customer as (
+    select
+        customer_id,
+        ceiling(cast(total_days as numeric) / 7.0) as week
+    from days_as_customer
+    group by customer_id, week
 ),
 
 customer_orders as (
     select
-        customer_id,
-        cast(date_trunc(created_at, week) as date) as order_week,
+        orders.customer_id,
+        case
+            when date_diff(orders.created_at, customers.first_order_at, day) = 0 then 1 -- customers first order should be represented as week 1 of being a customer
+            else ceiling(cast(date_diff(orders.created_at, customers.first_order_at, day) as numeric) / 7.0) -- ie. 17 days → 2.4 wks → ceiling(2.4) = week 3 as customer
+        end as order_week,
         sum(total) as revenue
-    from {{ ref('stg_orders') }}
+    from {{ ref('stg_orders') }} orders
+        left join {{ ref('dim_customers') }} customers on orders.customer_id = customers.customer_id
     group by customer_id, order_week
 )
 
@@ -25,4 +36,4 @@ select
     sum(coalesce(revenue, 0)) over (partition by weeks_as_customer.customer_id order by week) as cumulative_revenue
 from weeks_as_customer
     left join customer_orders on weeks_as_customer.customer_id = customer_orders.customer_id
-        and weeks_as_customer.date_week = customer_orders.order_week
+        and weeks_as_customer.week = customer_orders.order_week

--- a/models/marts/customers_weekly_metrics.sql
+++ b/models/marts/customers_weekly_metrics.sql
@@ -1,20 +1,11 @@
-with calendar as (
-    {{ dbt_utils.date_spine(
-        datepart="week",
-        start_date="cast(date_trunc('2021-01-01', week) as date)",
-        end_date="cast(current_date() as date)"
-        )
-    }}
-),
-
-weeks_as_customer as (
+with weeks_as_customer as (
     select
         customer_id,
         row_number() over (partition by customer_id order by calendar.date_week) as week,
         calendar.date_week
     
     from {{ ref('dim_customers') }} customers
-        cross join calendar
+        cross join {{ ref('calendar_weeks') }} calendar
     where calendar.date_week >= cast(date_trunc(customers.first_order_at, week) as date)
 ),
 


### PR DESCRIPTION
Creating a PR just to show an example of how one could base the `week` in the customer metrics off the exact days since becoming a customer vs the week bucket (aka `date_trunc()`) of the calendar week that the order falls within.

It's important to remember that the week bucket of the calendar is best to use for cohort LTV scenarios due to its ability to normalize trends for the group as a whole, and this is why this PR will not be merged.