### PR TITLE
week5-partitioning-and-clustering

### DIFF
--- a/models/marts/dim_customers.sql
+++ b/models/marts/dim_customers.sql
@@ -1,4 +1,11 @@
-{{ config(materialized='table') }}
+{{ config(
+    materialized='table',
+    partition_by = {
+        "field": "first_order_at",
+        "data_type": "datetime",
+        "granularity": "day"
+    }
+) }}
 
 with customer_orders as (
     select

--- a/models/marts/intermediate/int_sessionization.sql
+++ b/models/marts/intermediate/int_sessionization.sql
@@ -1,3 +1,13 @@
+{{ config(
+    materialized='table',
+    partition_by = {
+        "field": "occured_at",
+        "data_type": "datetime",
+        "granularity": "day"
+    },
+    cluster_by=['device_type', 'page']
+) }}
+
 with session_splitter as (
     select
         *,

--- a/models/marts/intermediate/int_sessionization.sql
+++ b/models/marts/intermediate/int_sessionization.sql
@@ -1,11 +1,6 @@
 {{ config(
     materialized='table',
-    partition_by = {
-        "field": "occured_at",
-        "data_type": "datetime",
-        "granularity": "day"
-    },
-    cluster_by=['device_type', 'page']
+    cluster_by=['customer_id', 'device_type', 'page']
 ) }}
 
 with session_splitter as (


### PR DESCRIPTION
**Partition**:
  - shards data across different machines/disks/nodes so that accessing rows from the different partitions can be done in parallel
  - each DW usually has rules around what data type can be partitioned, the allowed granularity, and the max number of partitions
 

**Cluster**:
  - can be thought of as how the data is ordered within a table/partition
  - just like in a sql `order by` statement, the order of which you're clustering by matters

Both of the above distributed computing methods can be implemented to decrease query runtimes, but some forethought should be used to understand potential trade-offs of the strategy as partitioning or clustering in a way that the data isn't normally analyzed/accessed can have the opposite effect and actually increase query runtimes.