### PR TITLE
week7-incremental-models

### DIFF
--- a/models/form_events.yml
+++ b/models/form_events.yml
@@ -1,0 +1,7 @@
+version: 2
+
+sources:
+  - name: advanced_dbt_examples
+    project: analytics-engineers-club
+    tables:
+      - name: form_events

--- a/models/form_respondents.sql
+++ b/models/form_respondents.sql
@@ -1,9 +1,18 @@
 {{ config(
-    materialized='table'
+    materialized='incremental'
 ) }}
 
 with events as (
     select * from {{ source('advanced_dbt_examples', 'form_events') }}
+
+    --the below is necessary for incremental models to tell dbt how to delineate what the new records are from the last run
+    {% if is_incremental() %}
+    where timestamp >= (select max(last_form_entry) from {{this}})
+    {% endif %}
+
+    -- where {{this}} represents the currently existing object mapped to this model
+    -- it's important that {{this}} is wrapped in an if statement:
+    -- because if this was the first run of the model it would get materialized as a table and {{this}} doesn't exist yet
 ),
 
 aggregated as (

--- a/models/form_respondents.sql
+++ b/models/form_respondents.sql
@@ -1,0 +1,19 @@
+{{ config(
+    materialized='table'
+) }}
+
+with events as (
+    select * from {{ source('advanced_dbt_examples', 'form_events') }}
+),
+
+aggregated as (
+    select
+        github_username,
+        min(timestamp) as first_form_entry,
+        max(timestamp) as last_form_entry,
+        count(*) as number_of_entries
+    from events
+    group by 1
+)
+
+select * from aggregated

--- a/models/form_respondents.sql
+++ b/models/form_respondents.sql
@@ -10,7 +10,10 @@ with events as (
     --the below is necessary for incremental models to tell dbt how to delineate what the new records are from the last run
     -- it's a good idea to account for data that could arrive a bit late
     {% if is_incremental() %}
-    where timestamp > (select date_add(max(last_form_entry), interval -1 hour) from {{this}})
+    where github_username in ( -- <- this ensures that previous records are not dropped from the model
+        select distinct github_username from {{ source('advanced_dbt_examples', 'form_events') }}
+        where timestamp > (select date_add(max(last_form_entry), interval -1 hour) from {{this}})
+    )
     {% endif %}
 
     -- where {{this}} represents the currently existing object mapped to this model


### PR DESCRIPTION
# Incremental Models

1. First run materializes all data as a new table
2. All future runs will only insert the new records (as defined in the model) to `{{ this }}` target table

- Need to tell dbt what to use to identify the last record (ie. `select max(last_form_entry) from table`) in order to know how to delineate the new records
	- Think about late records that could come in and how to handle those (ie. what are the scenarios? is late data actually a problem?)
- Make use of `unique_key` in the config block to tell the incremental model how to handle the new records if they need to be aggregated back to a single row for their given identifier
- Often an additional `where <unique_key> in ()` clause may be needed to ensure the old rows containing the updated key aren't dropped and replaced by only the new ones
- It's good practice to run a `--full-refresh` on incremental models once a week to guarantee you're not missing records, dropping records, etc.