### PR TITLE
week7-snapshots

### DIFF
--- a/models/marts/core/favorite_ice_creams_daily.sql
+++ b/models/marts/core/favorite_ice_creams_daily.sql
@@ -1,0 +1,9 @@
+select
+    github_username,
+    favorite_ice_cream_flavor,
+    date_day
+
+from {{ ref('calendar_days') }} calendar_days
+    join {{ ref('favorite_ice_cream_flavors') }} favorite_flavors on
+        calendar_days.date_day >= cast(favorite_flavors.dbt_valid_from as date)
+        and calendar_days.date_day < cast(coalesce(favorite_flavors.dbt_valid_to, cast(current_date()+1 as timestamp))  as date)

--- a/models/staging/forms/src_forms.yml
+++ b/models/staging/forms/src_forms.yml
@@ -1,0 +1,9 @@
+version: 2
+
+sources:
+  - name: advanced_dbt_examples
+    project: analytics-engineers-club
+
+    tables:
+      - name: favorite_ice_cream_flavors
+        description: tracks the most recent favorite ice cream flavor for a given individual

--- a/models/utils/calendar_days.sql
+++ b/models/utils/calendar_days.sql
@@ -1,0 +1,16 @@
+{{ config(materialized='table') }}
+
+with calendar as (
+    {{ dbt_utils.date_spine(
+        datepart="day",
+        start_date="cast('2021-11-14' as date)",
+        end_date="cast(current_date()+1 as date)"
+        )
+    }}
+)
+
+-- ^end_date isn't included so adding +1 so that this table contains the current_date()
+
+select *
+from calendar
+order by date_day

--- a/snapshots/favorite_ice_creams.sql
+++ b/snapshots/favorite_ice_creams.sql
@@ -1,0 +1,14 @@
+{% snapshot favorite_ice_cream_flavors %}
+-- ^ the name of the snapshot will come from this name vs the filename (dissimilar to models)
+-- it's often good practice to give snapshots their own unique schema
+{{ config(
+      target_schema='dbt_meehan_snapshots',
+      unique_key='github_username',
+      strategy='timestamp',
+      updated_at='updated_at'
+) }}
+
+select *
+from {{ source('advanced_dbt_examples', 'favorite_ice_cream_flavors') }}
+
+{% endsnapshot %}


### PR DESCRIPTION
# Snapshots

Limitations of snapshots:
- They only record change history each time they are run
- If a field changes twice before the next snapshot is run, the snapshot will only capture the most recent change as the first change will have been overwritten before the snapshot ran

---

Query to understand favorite ice creams on a daily basis:
```sql
select
    date_day,
    favorite_ice_cream_flavor as flavor,
    count(favorite_ice_cream_flavor) as number_of_favorites
from `aec-2021-10-mondays.dbt_meehan.favorite_ice_creams_daily`
group by 1,2
order by 1
```